### PR TITLE
Fix flipping animation in title

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -213,10 +213,20 @@
 /* Flipping text animation */
 .flipping-text {
   display: inline-block;
-  transition: transform 0.5s ease, opacity 0.5s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .flipping-text.flip {
-  transform: rotateX(180deg);
+  transform: translateY(10px);
   opacity: 0;
+}
+
+.flipping-text.fade-out {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.flipping-text.fade-in {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -140,12 +140,16 @@ function initFlippingText() {
   let currentIndex = 0;
 
   setInterval(() => {
-    flippingTextElement.classList.add('flip');
+    flippingTextElement.classList.add('fade-out');
     setTimeout(() => {
       flippingTextElement.textContent = texts[currentIndex];
       flippingTextElement.style.color = colors[Math.floor(Math.random() * colors.length)];
-      flippingTextElement.classList.remove('flip');
+      flippingTextElement.classList.remove('fade-out');
+      flippingTextElement.classList.add('fade-in');
+      setTimeout(() => {
+        flippingTextElement.classList.remove('fade-in');
+      }, 200);
       currentIndex = (currentIndex + 1) % texts.length;
-    }, 500);
+    }, 200);
   }, 1000);
 }


### PR DESCRIPTION
Update the flipping text animation to use fade and translate effects instead of a 180-degree flip.

* **CSS Changes:**
  - Modify `.flipping-text` class to use `transition: opacity 0.2s ease, transform 0.2s ease`.
  - Add `.flipping-text.fade-out` class with `opacity: 0; transform: translateY(10px);`.
  - Add `.flipping-text.fade-in` class with `opacity: 1; transform: translateY(0);`.

* **JavaScript Changes:**
  - Update `initFlippingText` function to add `fade-out` class before changing text.
  - Remove `fade-out` class and add `fade-in` class after changing text.
  - Remove `fade-in` class after the transition is complete.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/championswimmer/midpoint-place-landing-page/pull/6?shareId=aab855e9-8fcc-4410-b7e0-c32fab2e59aa).